### PR TITLE
Add metadata generation tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  TERM: xterm
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+      - name: Restore dependencies
+        run: dotnet restore DotnetLegacyMigrator.sln
+      - name: Build
+        run: dotnet build DotnetLegacyMigrator.sln --no-restore -c Release
+      - name: Test
+        run: dotnet test DotnetLegacyMigrator.sln --no-build -c Release --logger "console;verbosity=normal"

--- a/DotnetLegacyMigrator.sln
+++ b/DotnetLegacyMigrator.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetLegacyMigrator.Core",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetLegacyMigrator.Cli", "src\Cli\DotnetLegacyMigrator.Cli.csproj", "{D2FF8D4D-BEA3-49E3-8A19-F12849D6031A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EF960348-F10A-4FE2-A272-0861F08757E6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Translation.Tests", "tests\Translation.Tests\Translation.Tests.csproj", "{A20BD492-30F7-439A-B3F6-EE27064B6C47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,9 +30,14 @@ Global
 		{D2FF8D4D-BEA3-49E3-8A19-F12849D6031A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2FF8D4D-BEA3-49E3-8A19-F12849D6031A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2FF8D4D-BEA3-49E3-8A19-F12849D6031A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A20BD492-30F7-439A-B3F6-EE27064B6C47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A20BD492-30F7-439A-B3F6-EE27064B6C47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A20BD492-30F7-439A-B3F6-EE27064B6C47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A20BD492-30F7-439A-B3F6-EE27064B6C47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5FAB3D92-B687-40DE-B868-6603FA3AA39D} = {164A6B40-F494-4E85-80D4-82436900F924}
 		{D2FF8D4D-BEA3-49E3-8A19-F12849D6031A} = {164A6B40-F494-4E85-80D4-82436900F924}
+		{A20BD492-30F7-439A-B3F6-EE27064B6C47} = {EF960348-F10A-4FE2-A272-0861F08757E6}
 	EndGlobalSection
 EndGlobal

--- a/src/Core/CodeGenerator.cs
+++ b/src/Core/CodeGenerator.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using DotnetLegacyMigrator.Models;
+
+namespace DotnetLegacyMigrator;
+
+public static class CodeGenerator
+{
+    private static readonly Dictionary<string, string> _primitiveAliases = new()
+    {
+        ["String"] = "string",
+        ["Int32"] = "int",
+        ["Int16"] = "short",
+        ["Int64"] = "long",
+        ["Boolean"] = "bool",
+        ["Decimal"] = "decimal",
+        ["Double"] = "double",
+        ["Single"] = "float",
+        ["Byte"] = "byte"
+    };
+
+    private static string NormalizeType(string type) =>
+        _primitiveAliases.TryGetValue(type.TrimEnd('?'), out var alias)
+            ? alias + (type.EndsWith("?") ? "?" : string.Empty)
+            : type;
+
+    public static string GenerateEntities(IEnumerable<Entity> entities)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("using System.ComponentModel.DataAnnotations;");
+        sb.AppendLine("using System.ComponentModel.DataAnnotations.Schema;");
+        sb.AppendLine();
+        foreach (var entity in entities)
+        {
+            sb.AppendLine($"[Table(\"{entity.TableName}\")]");
+            sb.AppendLine($"public class {entity.Name}");
+            sb.AppendLine("{");
+            foreach (var prop in entity.Properties)
+            {
+                if (prop.IsPrimaryKey)
+                    sb.AppendLine("    [Key]");
+                if (prop.IsDbGenerated)
+                    sb.AppendLine("    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]");
+                var columnName = string.IsNullOrWhiteSpace(prop.ColumnName) ? prop.Name : prop.ColumnName;
+                var columnArgs = new List<string> { $"\"{columnName}\"" };
+                if (!string.IsNullOrWhiteSpace(prop.DbType))
+                    columnArgs.Add($"TypeName = \"{prop.DbType}\"");
+                sb.AppendLine($"    [Column({string.Join(", ", columnArgs)})]");
+                sb.AppendLine($"    public {NormalizeType(prop.Type)} {prop.Name} {{ get; set; }}");
+                sb.AppendLine();
+            }
+            sb.AppendLine("}");
+            sb.AppendLine();
+        }
+        return sb.ToString().Trim();
+    }
+
+    public static string GenerateDataContext(DataContext context)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("using Microsoft.EntityFrameworkCore;");
+        sb.AppendLine();
+        sb.AppendLine($"public class {context.Name} : DbContext");
+        sb.AppendLine("{");
+        foreach (var table in context.Tables)
+            sb.AppendLine($"    public DbSet<{table.EntityType}> {table.Name} {{ get; set; }}");
+        sb.AppendLine("}");
+        return sb.ToString().Trim();
+    }
+}

--- a/src/Core/MetadataCollector.cs
+++ b/src/Core/MetadataCollector.cs
@@ -1,0 +1,67 @@
+using DotnetLegacyMigrator.Models;
+using DotnetLegacyMigrator.Syntax;
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace DotnetLegacyMigrator;
+
+/// <summary>
+/// Helper that uses the existing syntax walkers to produce metadata
+/// for DataContexts and Entities without modifying the source projects.
+/// </summary>
+public static class MetadataCollector
+{
+    public static async Task<(List<DataContext> Contexts, List<Entity> Entities)> CollectAsync(string solutionPath)
+    {
+        if (!MSBuildLocator.IsRegistered)
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+        var _ = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions);
+
+        using var workspace = MSBuildWorkspace.Create();
+        var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+        var contexts = new List<DataContext>();
+        var entities = new List<Entity>();
+
+        foreach (var project in solution.Projects)
+        {
+            foreach (var document in project.Documents)
+            {
+                var root = await document.GetSyntaxRootAsync();
+                if (root == null) continue;
+
+                var linqCtx = new LinqToSqlContextSyntaxWalker();
+                var linqEntities = new LinqToSqlEntitySyntaxWalker();
+                var datasetCtx = new TypedDatasetSyntaxWalker();
+                var datasetEntities = new TypedDatasetEntitySyntaxWalker();
+
+                linqCtx.Visit(root);
+                linqEntities.Visit(root);
+                datasetCtx.Visit(root);
+                datasetEntities.Visit(root);
+
+                contexts.AddRange(linqCtx.Contexts);
+                contexts.AddRange(datasetCtx.Contexts);
+                entities.AddRange(linqEntities.Entities);
+                entities.AddRange(datasetEntities.Entities);
+            }
+
+            // NHibernate mapping files live outside of C# documents
+            var projectDir = Path.GetDirectoryName(project.FilePath);
+            if (projectDir != null)
+            {
+                var hbmFiles = Directory.GetFiles(projectDir, "*.hbm.xml", SearchOption.AllDirectories);
+                if (hbmFiles.Length > 0)
+                {
+                    var (ctx, nhEntities) = NHibernateHbmParser.ParseFiles(hbmFiles);
+                    contexts.Add(ctx);
+                    entities.AddRange(nhEntities);
+                }
+            }
+        }
+
+        return (contexts, entities);
+    }
+}

--- a/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
@@ -14,7 +14,7 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
     {
         var tableAttribute = node.AttributeLists
             .SelectMany(al => al.Attributes)
-            .FirstOrDefault(a => a.Name.ToString().Contains("TableAttribute"));
+            .FirstOrDefault(a => a.Name.ToString().Contains("Table"));
 
         if (tableAttribute != null)
         {
@@ -144,7 +144,9 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
     {
         return p.AttributeLists
             .SelectMany(al => al.Attributes)
-            .Any(a => a.ToString().Contains("IsPrimaryKey=true"));
+            .Any(a => a.ArgumentList?.Arguments
+                .Any(arg => arg.NameEquals?.Name.Identifier.Text == "IsPrimaryKey" &&
+                             arg.Expression.ToString().Contains("true")) ?? false);
     }
 
     private static string GetMetadata(PropertyDeclarationSyntax p)

--- a/src/Core/Syntax/NHibernateHbmParser.cs
+++ b/src/Core/Syntax/NHibernateHbmParser.cs
@@ -1,0 +1,80 @@
+using System.Xml.Linq;
+using DotnetLegacyMigrator.Models;
+
+namespace DotnetLegacyMigrator.Syntax;
+
+/// <summary>
+/// Minimal parser for NHibernate .hbm.xml mapping files to reuse existing
+/// metadata models.
+/// </summary>
+public static class NHibernateHbmParser
+{
+    private static readonly XNamespace Ns = "urn:nhibernate-mapping-2.2";
+
+    public static (DataContext Context, List<Entity> Entities) ParseFiles(IEnumerable<string> hbmFiles)
+    {
+        var entities = new List<Entity>();
+        var tables = new List<TableMapping>();
+        string? assembly = null;
+
+        foreach (var file in hbmFiles)
+        {
+            var doc = XDocument.Load(file);
+            var root = doc.Element(Ns + "hibernate-mapping");
+            assembly ??= root?.Attribute("assembly")?.Value;
+            foreach (var classEl in root?.Elements(Ns + "class") ?? Enumerable.Empty<XElement>())
+            {
+                var name = classEl.Attribute("name")?.Value ?? "Entity";
+                var table = classEl.Attribute("table")?.Value ?? name;
+                var props = new List<EntityProperty>();
+
+                var idEl = classEl.Element(Ns + "id");
+                if (idEl != null)
+                {
+                    var idName = idEl.Attribute("name")?.Value ?? "Id";
+                    var type = idEl.Attribute("type")?.Value ?? "Int32";
+                    var gen = idEl.Element(Ns + "generator");
+                    props.Add(new EntityProperty
+                    {
+                        Name = idName,
+                        Type = type,
+                        ColumnName = idName,
+                        IsPrimaryKey = true,
+                        IsDbGenerated = gen != null
+                    });
+                }
+
+                foreach (var p in classEl.Elements(Ns + "property"))
+                {
+                    var propName = p.Attribute("name")?.Value ?? "Prop";
+                    var type = p.Attribute("type")?.Value ?? "String";
+                    props.Add(new EntityProperty
+                    {
+                        Name = propName,
+                        Type = type,
+                        ColumnName = propName
+                    });
+                }
+
+                entities.Add(new Entity
+                {
+                    Name = name,
+                    TableName = table,
+                    Properties = props
+                });
+
+                tables.Add(new TableMapping { Name = table, EntityType = name });
+            }
+        }
+
+        var contextName = (assembly ?? "NHibernate") + "Context";
+        var ctx = new DataContext
+        {
+            Name = contextName,
+            Tables = tables,
+            StoredProcedures = new List<StoredProcedureMapping>()
+        };
+
+        return (ctx, entities);
+    }
+}

--- a/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
@@ -15,7 +15,7 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
     {
 
         if (node.BaseList != null && node.BaseList.Types
-            .Any(t => t.Type.ToString().Contains("TypedTableBase")))
+            .Any(t => t.Type.ToString().Contains("TypedTableBase") || t.Type.ToString().Contains("DataTable")))
         {
             // get the .cs file path
             var csFile = node.SyntaxTree.FilePath;
@@ -35,7 +35,7 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
             ds.ReadXmlSchema(reader);
 
             var className = node.Identifier.ToString().Replace("DataTable", "");
-            var tableName = ExtractTableName(node);
+            var tableName = ExtractTableName(node) ?? className;
 
             var dt = ds.Tables[tableName];
             if (dt != null)
@@ -63,7 +63,7 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
         base.VisitClassDeclaration(node);
     }
 
-    private string ExtractTableName(ClassDeclarationSyntax classNode)
+    private string? ExtractTableName(ClassDeclarationSyntax classNode)
     {
         // look for the ctor whose name matches the class
         var ctor = classNode.Members
@@ -89,7 +89,7 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
         }
 
         // fallback to class name (or whatever default you prefer)
-        return classNode.Identifier.Text;
+        return null;
     }
 
 

--- a/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
@@ -224,7 +224,8 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
         foreach (var member in datasetClass.Members.OfType<ClassDeclarationSyntax>())
         {
             if (member.BaseList != null &&
-                member.BaseList.Types.Any(t => t.Type.ToString().Contains("TypedTableBase")))
+                member.BaseList.Types.Any(t => t.Type.ToString().Contains("TypedTableBase") ||
+                                             t.Type.ToString().Contains("DataTable")))
             {
                 if (member.Identifier.ToString() == "DataTable1")
                     continue;

--- a/tests/Translation.Tests/ExampleTranslationTests.cs
+++ b/tests/Translation.Tests/ExampleTranslationTests.cs
@@ -1,0 +1,56 @@
+using DotnetLegacyMigrator;
+using Xunit;
+
+namespace Translation.Tests;
+
+public class ExampleTranslationTests
+{
+    private static async Task<(string DataContext, string Entities)> GenerateAsync(string solution)
+    {
+        var (contexts, entities) = await MetadataCollector.CollectAsync(solution);
+        var ctxText = CodeGenerator.GenerateDataContext(contexts.Single());
+        var entityText = CodeGenerator.GenerateEntities(entities);
+        return (ctxText, entityText);
+    }
+
+    private static string ExpectedPath(params string[] parts)
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        return Path.Combine(new[] { root }.Concat(parts).ToArray());
+    }
+
+    [Fact]
+    public async Task LinqToSql_ProjectProducesExpectedOutput()
+    {
+        var sol = ExpectedPath("examples", "LinqToSql", "LinqToSqlDemo.sln");
+        var (dataCtx, entities) = await GenerateAsync(sol);
+        var expectedCtx = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "LinqToSql", "DataContext.txt"));
+        var expectedEnt = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "LinqToSql", "Entities.txt"));
+        Assert.Equal(Normalize(expectedCtx), Normalize(dataCtx));
+        Assert.Equal(Normalize(expectedEnt), Normalize(entities));
+    }
+
+    [Fact]
+    public async Task TypedDataSet_ProjectProducesExpectedOutput()
+    {
+        var sol = ExpectedPath("examples", "TypedDataSets", "TypedDataSetDemo.sln");
+        var (dataCtx, entities) = await GenerateAsync(sol);
+        var expectedCtx = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "DataContext.txt"));
+        var expectedEnt = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "Entities.txt"));
+        Assert.Equal(Normalize(expectedCtx), Normalize(dataCtx));
+        Assert.Equal(Normalize(expectedEnt), Normalize(entities));
+    }
+
+    [Fact]
+    public async Task NHibernate_ProjectProducesExpectedOutput()
+    {
+        var sol = ExpectedPath("examples", "NHibernate", "NHibernateDemo.sln");
+        var (dataCtx, entities) = await GenerateAsync(sol);
+        var expectedCtx = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "NHibernate", "DataContext.txt"));
+        var expectedEnt = await File.ReadAllTextAsync(ExpectedPath("tests", "Translation.Tests", "Expected", "NHibernate", "Entities.txt"));
+        Assert.Equal(Normalize(expectedCtx), Normalize(dataCtx));
+        Assert.Equal(Normalize(expectedEnt), Normalize(entities));
+    }
+
+    private static string Normalize(string input) => input.Replace("\r\n", "\n").Trim();
+}

--- a/tests/Translation.Tests/Expected/LinqToSql/DataContext.txt
+++ b/tests/Translation.Tests/Expected/LinqToSql/DataContext.txt
@@ -1,0 +1,6 @@
+using Microsoft.EntityFrameworkCore;
+
+public class NorthwindDataContext : DbContext
+{
+    public DbSet<Customer> Customers { get; set; }
+}

--- a/tests/Translation.Tests/Expected/LinqToSql/Entities.txt
+++ b/tests/Translation.Tests/Expected/LinqToSql/Entities.txt
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("Customers")]
+public class Customer
+{
+    [Key]
+    [Column("CustomerID")]
+    public int CustomerID { get; set; }
+
+    [Column("CompanyName")]
+    public string? CompanyName { get; set; }
+
+}

--- a/tests/Translation.Tests/Expected/NHibernate/DataContext.txt
+++ b/tests/Translation.Tests/Expected/NHibernate/DataContext.txt
@@ -1,0 +1,6 @@
+using Microsoft.EntityFrameworkCore;
+
+public class NHibernateDemoContext : DbContext
+{
+    public DbSet<Customer> Customers { get; set; }
+}

--- a/tests/Translation.Tests/Expected/NHibernate/Entities.txt
+++ b/tests/Translation.Tests/Expected/NHibernate/Entities.txt
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("Customers")]
+public class Customer
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [Column("Name")]
+    public string Name { get; set; }
+
+}

--- a/tests/Translation.Tests/Expected/TypedDataSets/DataContext.txt
+++ b/tests/Translation.Tests/Expected/TypedDataSets/DataContext.txt
@@ -1,0 +1,6 @@
+using Microsoft.EntityFrameworkCore;
+
+public class NorthwindDataSet : DbContext
+{
+    public DbSet<Customers> Customers { get; set; }
+}

--- a/tests/Translation.Tests/Expected/TypedDataSets/Entities.txt
+++ b/tests/Translation.Tests/Expected/TypedDataSets/Entities.txt
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("Customers")]
+public class Customers
+{
+    [Key]
+    [Column("CustomerID")]
+    public int CustomerID { get; set; }
+
+    [Column("CompanyName")]
+    public string CompanyName { get; set; }
+
+}

--- a/tests/Translation.Tests/Translation.Tests.csproj
+++ b/tests/Translation.Tests/Translation.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Core/DotnetLegacyMigrator.Core.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- generate EF-style code from collected metadata
- support NHibernate mappings and LINQ-to-SQL fields
- test example projects against expected context/entity output
- build and test in CI using a console logger

## Testing
- `dotnet build DotnetLegacyMigrator.sln -c Release`
- `dotnet test DotnetLegacyMigrator.sln --no-build -c Release --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68a4261dbd948328afeb4b9f94943884