### PR TITLE
Prune unused metadata and tackle nullability

### DIFF
--- a/src/Core/Models/DataContext.cs
+++ b/src/Core/Models/DataContext.cs
@@ -5,7 +5,7 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class DataContext
 {
-    public string Name { get; set; }
-    public List<TableMapping> Tables { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<TableMapping> Tables { get; set; } = new();
     public List<StoredProcedureMapping> StoredProcedures { get; set; } = new();
 }

--- a/src/Core/Models/Entity.cs
+++ b/src/Core/Models/Entity.cs
@@ -5,7 +5,7 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class Entity
 {
-    public string Name { get; set; }
-    public List<EntityProperty> Properties { get; set; }
-    public string TableName { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<EntityProperty> Properties { get; set; } = new();
+    public string TableName { get; set; } = string.Empty;
 }

--- a/src/Core/Models/EntityProperty.cs
+++ b/src/Core/Models/EntityProperty.cs
@@ -5,19 +5,11 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class EntityProperty
 {
-    public string Name { get; set; }
-    public string Type { get; set; }
-    public string Metadata { get; set; }
-    public string ColumnName { get; set; }
-    public string DbType { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string? ColumnName { get; set; }
+    public string? DbType { get; set; }
     public bool IsPrimaryKey { get; set; }
     public bool IsDbGenerated { get; set; }
     public bool IsNullable { get; set; }
-    public int Order { get; set; }
-    public int? MaxLength { get; set; }
-    public string ForeignKey { get; set; }
-    public string ForeignEntity { get; set; }
-    public bool ForeignMany { get; set; }
-    public bool SelfMany { get; set; }
-    public bool CascadeDelete { get; set; }
 }

--- a/src/Core/Models/ParameterMapping.cs
+++ b/src/Core/Models/ParameterMapping.cs
@@ -5,7 +5,7 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class ParameterMapping
 {
-    public string Name { get; set; }
-    public string Type { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
     public bool IsNullable { get; set; }
 }

--- a/src/Core/Models/StoredProcedureMapping.cs
+++ b/src/Core/Models/StoredProcedureMapping.cs
@@ -5,8 +5,8 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class StoredProcedureMapping
 {
-    public string MethodName { get; set; }
-    public string ReturnType { get; set; }
+    public string MethodName { get; set; } = string.Empty;
+    public string ReturnType { get; set; } = string.Empty;
     public List<ParameterMapping> Parameters { get; set; } = new();
-    public string StoredProcName { get; set; }
+    public string StoredProcName { get; set; } = string.Empty;
 }

--- a/src/Core/Models/StoredProcedureResult.cs
+++ b/src/Core/Models/StoredProcedureResult.cs
@@ -5,6 +5,6 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class StoredProcedureResult
 {
-    public string Name { get; set; }
-    public List<EntityProperty> Properties { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public List<EntityProperty> Properties { get; set; } = new();
 }

--- a/src/Core/Models/TableMapping.cs
+++ b/src/Core/Models/TableMapping.cs
@@ -5,6 +5,6 @@ namespace DotnetLegacyMigrator.Models;
 /// </summary>
 public class TableMapping
 {
-    public string Name { get; set; }
-    public string EntityType { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string EntityType { get; set; } = string.Empty;
 }

--- a/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
@@ -18,8 +18,9 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
 
         if (tableAttribute != null)
         {
-            var tableName = tableAttribute.ArgumentList.Arguments
-                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Name")?.Expression.ToString().Trim('"');
+            var tableName = tableAttribute.ArgumentList?.Arguments
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Name")?
+                .Expression?.ToString().Trim('"');
 
 
             var entity = new Entity
@@ -37,36 +38,25 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
             {
                 Name = node.Identifier.ToString(),
                 Properties = node.Members.OfType<PropertyDeclarationSyntax>()
-                    .Select((p, index) => new EntityProperty
+                    .Select(p => new EntityProperty
                     {
                         Name = p.Identifier.ToString(),
                         Type = p.Type.ToString(),
-                        Metadata = string.Join(", ", p.AttributeLists
-                            .SelectMany(al => al.Attributes)
-                            .Select(a => a.ToString())),
                         ColumnName = p.AttributeLists
                             .SelectMany(al => al.Attributes)
                             .Where(a => a.ToString().Contains("Storage="))
-                            .Select(a => a.ArgumentList.Arguments
-                                .FirstOrDefault(arg => arg.NameEquals.Name.Identifier.Text == "Storage")?.Expression
-                                .ToString().Trim('"'))
+                            .Select(a => a.ArgumentList?.Arguments
+                                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Storage")?
+                                .Expression?.ToString().Trim('"'))
                             .FirstOrDefault(),
                         DbType = p.AttributeLists
                             .SelectMany(al => al.Attributes)
                             .Where(a => a.ToString().Contains("DbType="))
-                            .Select(a => a.ArgumentList.Arguments
-                                .FirstOrDefault(arg => arg.NameEquals.Name.Identifier.Text == "DbType")?.Expression
-                                .ToString().Trim('"'))
+                            .Select(a => a.ArgumentList?.Arguments
+                                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "DbType")?
+                                .Expression?.ToString().Trim('"'))
                             .FirstOrDefault(),
-                        IsNullable = p.AttributeLists
-                            .SelectMany(al => al.Attributes)
-                            .Any(a => a.ToString().Contains("CanBeNull=true")),
-                        Order = index + 1,
-                        MaxLength = p.AttributeLists
-                            .SelectMany(al => al.Attributes)
-                            .Where(a => a.ToString().Contains("NVarChar"))
-                            .Select(ExtractMaxLength)
-                            .FirstOrDefault(x => x != null)
+                        IsNullable = GetIsNullable(p)
                     }).ToList()
             };
             StoredProcedureResults.Add(result);
@@ -75,40 +65,18 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
         base.VisitClassDeclaration(node);
     }
 
-    private EntityProperty GetEntityProperty(PropertyDeclarationSyntax p, int index)
+    private EntityProperty GetEntityProperty(PropertyDeclarationSyntax p)
     {
         return new EntityProperty
         {
             Name = p.Identifier.ToString(),
             Type = p.Type.ToString(),
-            Metadata = GetMetadata(p),
             IsPrimaryKey = GetIsPrimaryKey(p),
             IsDbGenerated = GetIsDbGenerated(p),
             ColumnName = GetColumnName(p),
             DbType = GetDbType(p),
-            Order = index + 1,
-            MaxLength = GetMaxLength(p),
-
-            // Extracting association properties
-            ForeignKey = GetForeignKey(p),
-
-            ForeignEntity = GetForeignEntity(p),
-
-            ForeignMany = GetForeignMany(p),
-
-            SelfMany = GetSelfMany(p),
-
-            CascadeDelete = GetCascadeDelete(p)
+            IsNullable = GetIsNullable(p)
         };
-    }
-
-    private int? GetMaxLength(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("NVarChar"))
-            .Select(ExtractMaxLength)
-            .FirstOrDefault(x => x != null);
     }
 
     private static string? GetDbType(PropertyDeclarationSyntax p)
@@ -116,8 +84,8 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
         return p.AttributeLists
             .SelectMany(al => al.Attributes)
             .Select(a => a.ArgumentList?.Arguments
-                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "DbType")?.Expression
-                .ToString().Trim('"'))
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "DbType")?
+                .Expression?.ToString().Trim('"'))
             .FirstOrDefault(s => !string.IsNullOrEmpty(s));
     }
 
@@ -126,9 +94,9 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
         return p.AttributeLists
             .SelectMany(al => al.Attributes)
             .Where(a => a.ToString().Contains("Name="))
-            .Select(a => a.ArgumentList.Arguments
-                .FirstOrDefault(arg => arg.NameEquals.Name.Identifier.Text == "Name")?.Expression
-                .ToString().Trim('"'))
+            .Select(a => a.ArgumentList?.Arguments
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Name")?
+                .Expression?.ToString().Trim('"'))
             .FirstOrDefault();
     }
 
@@ -148,77 +116,12 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
                              arg.Expression.ToString().Contains("true")) ?? false);
     }
 
-    private static string GetMetadata(PropertyDeclarationSyntax p)
+    private static bool GetIsNullable(PropertyDeclarationSyntax p)
     {
-        return string.Join(", ", p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Select(a => a.ToString()));
-    }
-
-    private static bool GetCascadeDelete(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("AssociationAttribute"))
-            .Any(a => a.ArgumentList.Arguments
-                .Any(arg => arg.NameEquals?.Name.Identifier.Text == "DeleteRule" &&
-                            arg.Expression.ToString().Contains("CASCADE")));
-    }
-
-    private static bool GetSelfMany(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("AssociationAttribute"))
-            .Any(a => a.ArgumentList.Arguments
-                .Any(arg => arg.NameEquals?.Name.Identifier.Text == "IsForeignKey" &&
-                            arg.Expression.ToString().Contains("true")));
-    }
-
-    private static bool GetForeignMany(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("AssociationAttribute"))
-            .Any(a => a.ArgumentList.Arguments
-                .Any(arg => arg.NameEquals?.Name.Identifier.Text == "IsForeignKey" &&
-                            arg.Expression.ToString().Contains("false")));
-    }
-
-    private static string? GetForeignEntity(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("AssociationAttribute"))
-            .Select(a => a.ArgumentList.Arguments
-                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "OtherKey")?.Expression
-                .ToString().Trim('"'))
-            .FirstOrDefault();
-    }
-
-    private static string? GetForeignKey(PropertyDeclarationSyntax p)
-    {
-        return p.AttributeLists
-            .SelectMany(al => al.Attributes)
-            .Where(a => a.ToString().Contains("AssociationAttribute"))
-            .Select(a => a.ArgumentList.Arguments
-                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "ThisKey")?.Expression
-                .ToString().Trim('"'))
-            .FirstOrDefault();
-    }
-
-    // Helper function to extract MaxLength from the attribute
-    private int? ExtractMaxLength(AttributeSyntax maxLengthAttribute)
-    {
-        var argumentString = maxLengthAttribute.ToString();
-        // Use regex to find the number inside parentheses after NVarChar
-        var match = System.Text.RegularExpressions.Regex.Match(argumentString, @"NVarChar\((\d+)\)");
-        if (match.Success && int.TryParse(match.Groups[1].Value, out var maxLength))
-        {
-            return maxLength;
-        }
-
-        return null;
+        return p.Type is NullableTypeSyntax ||
+            p.AttributeLists
+                .SelectMany(al => al.Attributes)
+                .Any(a => a.ToString().Contains("CanBeNull=true"));
     }
 
     private bool IsStoredProcedureResult(ClassDeclarationSyntax node)

--- a/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
@@ -104,20 +104,11 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
             {
                 Name = c.ColumnName,
                 Type = GetColumnType(c),
-                Metadata = string.Empty, // Metadata extraction not relevant for Typed Datasets
                 IsPrimaryKey = dt.PrimaryKey.Any(cc => cc == c) || dt.Columns.Count == 1, // This information is typically unavailable in the code
                 IsDbGenerated = false, // Same as above
                 ColumnName = c.ColumnName,
                 DbType = c.DataType == typeof(string) && c.MaxLength > 0 ? $"NVARCHAR({c.MaxLength})" : null,
-                Order = 0, // Order is irrelevant for columns in Typed Datasets
-                MaxLength = c.MaxLength != -1 ? c.MaxLength : null, // Max length not specified in this format
-
-                // Relationships are not typically encoded in Typed Dataset code
-                ForeignKey = null,
-                ForeignEntity = null,
-                ForeignMany = false,
-                SelfMany = false,
-                CascadeDelete = false
+                IsNullable = c.AllowDBNull
             };
         }
     }
@@ -133,25 +124,6 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
         }
 
         return c.DataType.Name;
-    }
-
-    private string? ExtractColumnName(ObjectCreationExpressionSyntax creation)
-    {
-        // First argument to DataColumn constructor is the column name
-        var columnNameArgument = creation.ArgumentList?.Arguments.FirstOrDefault();
-        return columnNameArgument?.Expression.ToString().Trim('"');
-    }
-
-    private string? ExtractColumnType(ObjectCreationExpressionSyntax creation)
-    {
-        // Second argument to DataColumn constructor is the type (typeof(...))
-        var typeArgument = creation.ArgumentList?.Arguments.ElementAtOrDefault(1)?.Expression;
-        if (typeArgument is TypeOfExpressionSyntax typeOfExpression)
-        {
-            return typeOfExpression.Type.ToString(); // Extract the actual type (e.g., "Guid", "string")
-        }
-
-        return null;
     }
 
 }


### PR DESCRIPTION
## Summary
- remove unused EF-era metadata from `EntityProperty` and related syntax walkers
- initialize core model properties to avoid nullability warnings
- streamline metadata walkers and compute property nullability

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a43b291b508328a6b6ecffe251d34f