### PR TITLE
Expand relationship migration tests across technologies

### DIFF
--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Customer.hbm.xml
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Customer.hbm.xml
@@ -1,0 +1,11 @@
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2">
+  <class name="Customer" table="Customers">
+    <id name="Id" column="Id" type="Int32">
+      <generator class="native"/>
+    </id>
+    <bag name="Orders" inverse="true">
+      <key column="CustomerId"/>
+      <one-to-many class="Order"/>
+    </bag>
+  </class>
+</hibernate-mapping>

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Entities.txt
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Entities.txt
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+
+[Table("Customers")]
+public class Customer
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [ForeignKey("CustomerId")]
+    public List<Order> Orders { get; set; } = new();
+
+}
+
+[Table("Orders")]
+public class Order
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [Column("CustomerId")]
+    public int CustomerId { get; set; }
+
+    [ForeignKey("CustomerId")]
+    public Customer Customer { get; set; }
+
+}

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Order.hbm.xml
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/Order.hbm.xml
@@ -1,0 +1,9 @@
+<hibernate-mapping xmlns="urn:nhibernate-mapping-2.2">
+  <class name="Order" table="Orders">
+    <id name="Id" column="Id" type="Int32">
+      <generator class="native"/>
+    </id>
+    <property name="CustomerId" column="CustomerId" type="Int32" not-null="true"/>
+    <many-to-one name="Customer" class="Customer" column="CustomerId"/>
+  </class>
+</hibernate-mapping>

--- a/tests/Translation.Tests/Expected/Relationships/TypedDataSets/Entities.txt
+++ b/tests/Translation.Tests/Expected/Relationships/TypedDataSets/Entities.txt
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+
+[Table("Customer")]
+public class Customer
+{
+    [Key]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [Column("Name", TypeName = "NVARCHAR(50)")]
+    public string Name { get; set; }
+
+    public List<Order> Orders { get; set; } = new();
+
+}
+
+[Table("Order")]
+public class Order
+{
+    [Key]
+    [Column("Id")]
+    public int Id { get; set; }
+
+    [Column("CustomerId")]
+    public int CustomerId { get; set; }
+
+    [ForeignKey("CustomerId")]
+    public Customer Customer { get; set; }
+
+}

--- a/tests/Translation.Tests/Expected/Relationships/TypedDataSets/RelDataSet.Designer.cs
+++ b/tests/Translation.Tests/Expected/Relationships/TypedDataSets/RelDataSet.Designer.cs
@@ -1,0 +1,17 @@
+using System.Data;
+
+public class CustomerDataTable : DataTable
+{
+    public CustomerDataTable()
+    {
+        this.TableName = "Customer";
+    }
+}
+
+public class OrderDataTable : DataTable
+{
+    public OrderDataTable()
+    {
+        this.TableName = "Order";
+    }
+}

--- a/tests/Translation.Tests/Expected/Relationships/TypedDataSets/RelDataSet.xsd
+++ b/tests/Translation.Tests/Expected/Relationships/TypedDataSets/RelDataSet.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema id="RelDataSet" xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xs:element name="RelDataSet" msdata:IsDataSet="true">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="Customer">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Id" type="xs:int" />
+              <xs:element name="Name">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:maxLength value="50" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Order">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Id" type="xs:int" />
+              <xs:element name="CustomerId" type="xs:int" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+    <xs:unique name="CustomerKey">
+      <xs:selector xpath=".//Customer" />
+      <xs:field xpath="Id" />
+    </xs:unique>
+    <xs:keyref name="OrderCustomer" refer="CustomerKey">
+      <xs:selector xpath=".//Order" />
+      <xs:field xpath="CustomerId" />
+    </xs:keyref>
+  </xs:element>
+</xs:schema>

--- a/tests/Translation.Tests/RelationshipMigrationTests.cs
+++ b/tests/Translation.Tests/RelationshipMigrationTests.cs
@@ -35,6 +35,40 @@ public class RelationshipMigrationTests
         Assert.Equal(Normalize(expected), Normalize(output));
     }
 
+    [Fact]
+    public void NHibernate_OneToMany_NavigationGenerated()
+    {
+        var customerHbm = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "Customer.hbm.xml"));
+        var orderHbm = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "Order.hbm.xml"));
+        var f1 = Path.GetTempFileName();
+        var f2 = Path.GetTempFileName();
+        File.WriteAllText(f1, customerHbm);
+        File.WriteAllText(f2, orderHbm);
+        var (_, entities) = NHibernateHbmParser.ParseFiles(new[] { f1, f2 });
+        var output = CodeGenerator.GenerateEntities(entities);
+        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "Entities.txt"));
+        Assert.Equal(Normalize(expected), Normalize(output));
+    }
+
+    [Fact]
+    public void TypedDataSet_OneToMany_NavigationGenerated()
+    {
+        var designer = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "RelDataSet.Designer.cs"));
+        var xsd = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "RelDataSet.xsd"));
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var designerPath = Path.Combine(dir, "RelDataSet.Designer.cs");
+        var xsdPath = Path.Combine(dir, "RelDataSet.xsd");
+        File.WriteAllText(designerPath, designer);
+        File.WriteAllText(xsdPath, xsd);
+        var tree = CSharpSyntaxTree.ParseText(designer, path: designerPath);
+        var walker = new TypedDatasetEntitySyntaxWalker();
+        walker.Visit(tree.GetRoot());
+        var output = CodeGenerator.GenerateEntities(walker.Entities);
+        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "Entities.txt"));
+        Assert.Equal(Normalize(expected), Normalize(output));
+    }
+
     private static string ExpectedPath(params string[] parts)
     {
         var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));


### PR DESCRIPTION
## Summary
- add NHibernate one-to-many relationship test and expected mappings
- cover Typed DataSet one-to-many relationships with designer, schema, and expected entities
- update relationship tests to run across all supported technologies

## Testing
- `DOTNET_ROLL_FORWARD=latestMajor dotnet test DotnetLegacyMigrator.sln -c Release --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68a4454b7bbc832881d68806c7c91d9b