### PR TITLE
Refactor LinqToSql table detection and add coverage

### DIFF
--- a/tests/Translation.Tests/LinqToSqlContextSyntaxWalkerTests.cs
+++ b/tests/Translation.Tests/LinqToSqlContextSyntaxWalkerTests.cs
@@ -1,0 +1,39 @@
+using DotnetLegacyMigrator.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Translation.Tests;
+
+public class LinqToSqlContextSyntaxWalkerTests
+{
+    [Fact]
+    public void CollectsTablesFromPropertiesAndFields()
+    {
+        const string source = """
+using System.Data.Linq;
+
+public class MyContext : DataContext
+{
+    public Table<Customer> Customers { get; }
+    public Table<Order> Orders;
+}
+""";
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var walker = new LinqToSqlContextSyntaxWalker();
+        walker.Visit(tree.GetRoot());
+
+        var context = Assert.Single(walker.Contexts);
+        Assert.Collection(context.Tables,
+            t =>
+            {
+                Assert.Equal("Customers", t.Name);
+                Assert.Equal("Customer", t.EntityType);
+            },
+            t =>
+            {
+                Assert.Equal("Orders", t.Name);
+                Assert.Equal("Order", t.EntityType);
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- refactor LinqToSqlContextSyntaxWalker to use shared helpers for table detection and entity type extraction
- add tests ensuring properties and fields representing Table<T> are recognized

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a45ad60f4483289c41ee709c7a0838