### PR TITLE
Inject logger into rewriters

### DIFF
--- a/src/Core/DotnetLegacyMigrator.Core.csproj
+++ b/src/Core/DotnetLegacyMigrator.Core.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Core/Rewriters/CtorInjectRewriter.cs
+++ b/src/Core/Rewriters/CtorInjectRewriter.cs
@@ -2,16 +2,25 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using DotnetLegacyMigrator.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DotnetLegacyMigrator.Rewriters;
 
 public class CtorInjectRewriter : CSharpSyntaxRewriter
 {
+    private readonly ILogger<CtorInjectRewriter> _logger;
+
+    public CtorInjectRewriter(ILogger<CtorInjectRewriter>? logger = null)
+    {
+        _logger = logger ?? NullLogger<CtorInjectRewriter>.Instance;
+    }
+
     public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         if (!node.ShouldProcess())
         {
-            Console.WriteLine("Skipping type " + node.Identifier.Text);
+            _logger.LogDebug("Skipping type {TypeName}", node.Identifier.Text);
             return node;
         }
 

--- a/src/Core/Rewriters/NewRewriter.cs
+++ b/src/Core/Rewriters/NewRewriter.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using CaseExtensions;
 using DotnetLegacyMigrator.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DotnetLegacyMigrator.Rewriters;
 
@@ -12,6 +14,12 @@ public class NewRewriter : CSharpSyntaxRewriter
 {
     private readonly Dictionary<string, string> _newTypesToFields = new();
     private readonly string _fieldPrefix = "_"; // You can change this based on your naming conventions
+    private readonly ILogger<NewRewriter> _logger;
+
+    public NewRewriter(ILogger<NewRewriter>? logger = null)
+    {
+        _logger = logger ?? NullLogger<NewRewriter>.Instance;
+    }
 
     public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
     {
@@ -42,7 +50,7 @@ public class NewRewriter : CSharpSyntaxRewriter
     {
         if (!node.ShouldProcess())
         {
-            Console.WriteLine("Skipping type " + node.Identifier.Text);
+            _logger.LogDebug("Skipping type {TypeName}", node.Identifier.Text);
             return node;
         }
 

--- a/src/Core/Rewriters/ResolveRewriter.cs
+++ b/src/Core/Rewriters/ResolveRewriter.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using CaseExtensions;
 using DotnetLegacyMigrator.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DotnetLegacyMigrator.Rewriters;
 
@@ -12,6 +14,12 @@ public class ResolveRewriter : CSharpSyntaxRewriter
 {
     private readonly Dictionary<string, string> _newTypesToFields = new();
     private readonly string _fieldPrefix = "_"; // You can change this based on your naming conventions
+    private readonly ILogger<ResolveRewriter> _logger;
+
+    public ResolveRewriter(ILogger<ResolveRewriter>? logger = null)
+    {
+        _logger = logger ?? NullLogger<ResolveRewriter>.Instance;
+    }
 
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
@@ -78,7 +86,7 @@ public class ResolveRewriter : CSharpSyntaxRewriter
     {
         if (!node.ShouldProcess())
         {
-            Console.WriteLine("Skipping type " + node.Identifier.Text);
+            _logger.LogDebug("Skipping type {TypeName}", node.Identifier.Text);
             return node;
         }
 

--- a/tests/Translation.Tests/LoggingTests.cs
+++ b/tests/Translation.Tests/LoggingTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using DotnetLegacyMigrator.Rewriters;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Translation.Tests;
+
+public class LoggingTests
+{
+    private const string SampleClass = "public class Skipped { public int Id { get; set; } }";
+
+    [Fact]
+    public void CtorInjectRewriter_Logs_Skipping()
+    {
+        var tree = CSharpSyntaxTree.ParseText(SampleClass);
+        var logger = new TestLogger<CtorInjectRewriter>();
+        var rewriter = new CtorInjectRewriter(logger);
+        rewriter.Visit(tree.GetRoot());
+
+        Assert.Contains(logger.Messages, m => m.Contains("Skipping type Skipped"));
+    }
+
+    [Fact]
+    public void CtorInjectRewriter_DisabledLogging_CapturesNoMessages()
+    {
+        var tree = CSharpSyntaxTree.ParseText(SampleClass);
+        var logger = new TestLogger<CtorInjectRewriter>(enabled: false);
+        var rewriter = new CtorInjectRewriter(logger);
+        rewriter.Visit(tree.GetRoot());
+
+        Assert.Empty(logger.Messages);
+    }
+
+    private class TestLogger<T> : ILogger<T>
+    {
+        private readonly bool _enabled;
+        public List<string> Messages { get; } = new();
+
+        public TestLogger(bool enabled = true)
+        {
+            _enabled = enabled;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => _enabled;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (_enabled)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace Console.WriteLine diagnostics in rewriters and syntax walker with ILogger
- accept logger through optional constructors so diagnostics can be disabled
- add tests showing logging capture and suppression

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a45ad03a5c8328be3d0c551b69278c