### PR TITLE
Ensure UTF-8 encoding without BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+# Use UTF-8 encoding without BOM
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/src/Core/Rewriters/CtorInjectRewriter.cs
+++ b/src/Core/Rewriters/CtorInjectRewriter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using DotnetLegacyMigrator.Utilities;

--- a/src/Core/Rewriters/ResolveRewriter.cs
+++ b/src/Core/Rewriters/ResolveRewriter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;

--- a/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using DotnetLegacyMigrator.Models;

--- a/src/Core/Utilities/Utils.cs
+++ b/src/Core/Utilities/Utils.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
## Summary
- enforce UTF-8 without BOM and final newline via repository-level `.editorconfig`
- remove byte-order marks and normalize line endings in core utility, syntax walker, and rewriter files

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a45dd606d88328ae4ef566b16099d7