### PR TITLE
Avoid multiple MSBuild registrations

### DIFF
--- a/src/Core/MigrationRunner.cs
+++ b/src/Core/MigrationRunner.cs
@@ -17,7 +17,12 @@ public class MigrationRunner
     /// </summary>
     public async Task RunAsync(string solutionPath)
     {
-        MSBuildLocator.RegisterDefaults();
+        if (!MSBuildLocator.IsRegistered)
+        {
+            // Register MSBuild only once to avoid exceptions on subsequent invocations
+            MSBuildLocator.RegisterDefaults();
+        }
+
         var _ = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions);
 
         if (!File.Exists(solutionPath))


### PR DESCRIPTION
## Summary
- register MSBuild only once in MigrationRunner
- keep CSharpFormattingOptions workaround after registration

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a463c31c3c83289e0c159712ab0115