### PR TITLE
Add business test for New and Resolve rewriters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,10 @@
 - Keep the repository's `global.json`, project files, and GitHub Actions in sync with the .NET 9 SDK.
 - Example projects may target different frameworks only when the legacy technology being demonstrated requires it.
 - When asserting generated output in tests, store the expected code under `tests/Translation.Tests/Expected` (or a relevant subfolder) rather than embedding it inline within the test source.
+- Ensure the .NET SDK version specified in `global.json` (currently `9.0.303`) is installed before running `dotnet` commands. If absent, install it using the official script:
+
+  ```bash
+  curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+  bash dotnet-install.sh -v 9.0.303
+  export PATH="$HOME/.dotnet:$PATH"
+  ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ that runs on .NET 9.
 
 ## Quickstart
 
-1. Install the [`.NET 9 SDK`](https://dotnet.microsoft.com/download).
+1. Install the [`.NET 9.0.303 SDK`](https://dotnet.microsoft.com/download). If it's not installed, you can add it locally with:
+
+   ```bash
+   curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+   bash dotnet-install.sh -v 9.0.303
+   export PATH="$HOME/.dotnet:$PATH"
+   ```
 2. Clone the repository:
 
    ```bash

--- a/tests/Translation.Tests/Expected/Rewriters/OrderTasks.txt
+++ b/tests/Translation.Tests/Expected/Rewriters/OrderTasks.txt
@@ -1,0 +1,22 @@
+public class OrderTasks
+{
+    private readonly IPaymentFacade _paymentFacade;
+    private readonly OrderConfig _orderConfig;
+    private readonly PaymentProcessor _paymentProcessor;
+    private readonly EmailSender _emailSender;
+    public OrderTasks(IPaymentFacade paymentFacade, OrderConfig orderConfig, PaymentProcessor paymentProcessor, EmailSender emailSender)
+    {
+        _paymentFacade = paymentFacade;
+        _orderConfig = orderConfig;
+        _paymentProcessor = paymentProcessor;
+        _emailSender = emailSender;
+    }
+
+    public void Run()
+    {
+        var processor = _paymentProcessor;
+        var facade = _paymentFacade;
+        var config = _orderConfig;
+        var sender = _emailSender;
+    }
+}

--- a/tests/Translation.Tests/NewResolveRewriterTests.cs
+++ b/tests/Translation.Tests/NewResolveRewriterTests.cs
@@ -1,0 +1,49 @@
+using DotnetLegacyMigrator.Rewriters;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using System.IO;
+using System.Linq;
+
+namespace Translation.Tests;
+
+public class NewResolveRewriterTests
+{
+    private static string ExpectedPath(params string[] parts)
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        return Path.Combine(new[] { root }.Concat(parts).ToArray());
+    }
+
+    private static string Normalize(string input) => input.Replace("\r\n", "\n").Trim();
+
+    [Fact]
+    public void NewAndResolveRewriters_ProduceConstructorInjection()
+    {
+        // Sample business code that mixes direct instantiation and a service locator
+        var code = @"
+public class OrderTasks
+{
+    public void Run()
+    {
+        var processor = new PaymentProcessor();
+        var facade = Globals.IoCContainer.Resolve<IPaymentFacade>();
+        var config = _resolver.Resolve<OrderConfig>();
+        var sender = new EmailSender();
+    }
+}";
+
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        // Replace "new" and service locator calls, then inject via ctor
+        root = new NewRewriter().Visit(root);
+        root = new ResolveRewriter().Visit(root);
+        root = new CtorInjectRewriter().Visit(root);
+
+        var actual = Normalize(root.NormalizeWhitespace().ToFullString());
+        var expected = Normalize(File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Rewriters", "OrderTasks.txt")));
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test covering New and Resolve rewriters converting direct instantiation and service locator usage to constructor injection
- add expected output file for OrderTasks scenario
- document installing the .NET 9.0.303 SDK so tests run on the right tooling

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a46bdc4e2c832883d6975cf62c1d2f