### PR TITLE
Handle examples directory moved

### DIFF
--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -1,11 +1,23 @@
 using DotnetLegacyMigrator;
 using Spectre.Console;
 
-var examplesDir = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "examples");
-var projects = Directory.GetDirectories(examplesDir)
-                        .Select(d => Path.GetFileName(d)!)
-                        .OrderBy(x => x)
-                        .ToList();
+// Resolve repository root from the compiled executable location.
+var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+// Examples were moved from `src/examples` to `/examples`.
+// Check both locations to remain compatible with older layouts.
+var examplesDir = Path.Combine(repoRoot, "examples");
+if (!Directory.Exists(examplesDir))
+{
+    examplesDir = Path.Combine(repoRoot, "src", "examples");
+}
+
+var projects = Directory.Exists(examplesDir)
+    ? Directory.GetDirectories(examplesDir)
+        .Select(d => Path.GetFileName(d)!)
+        .OrderBy(x => x)
+        .ToList()
+    : new List<string>();
 
 if (projects.Count == 0)
 {


### PR DESCRIPTION
## Summary
- resolve repo root and find examples folder in both `/examples` and `src/examples`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4e8ee588328b73b9e8367712738