### PR TITLE
Fix CLI example project discovery

### DIFF
--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -2,7 +2,10 @@ using DotnetLegacyMigrator;
 using Spectre.Console;
 
 // Resolve repository root from the compiled executable location.
-var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+// The CLI binaries are under `src/Cli/bin/<Configuration>/net9.0/`.
+// Moving five levels up reaches the repository root.
+var repoRoot = Path.GetFullPath(
+    Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
 
 // Examples were moved from `src/examples` to `/examples`.
 // Check both locations to remain compatible with older layouts.


### PR DESCRIPTION
## Summary
- correct repository root path resolution so CLI can find example projects

## Testing
- `dotnet run --project src/Cli`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4adbfaff88328906314a1e04cb50e