### PR TITLE
Show generated code for example projects

### DIFF
--- a/src/Core/DotnetLegacyMigrator.Core.csproj
+++ b/src/Core/DotnetLegacyMigrator.Core.csproj
@@ -15,6 +15,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Spectre.Console" Version="0.49.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- output generated entities, configurations, and DbContext code after running an example
- add simple syntax highlighting using Spectre.Console
- include Spectre.Console dependency in core library

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4afbc21788328b0921fcc9a1ba49c