### PR TITLE
Fix nullability warnings

### DIFF
--- a/src/Core/Rewriters/NewRewriter.cs
+++ b/src/Core/Rewriters/NewRewriter.cs
@@ -23,7 +23,7 @@ public class NewRewriter : CSharpSyntaxRewriter
         _logger = logger ?? NullLogger<NewRewriter>.Instance;
     }
 
-    public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+    public override SyntaxNode? VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
     {
         if (node.IsStaticMethodOrProperty())
         {
@@ -48,7 +48,7 @@ public class NewRewriter : CSharpSyntaxRewriter
         return SyntaxFactory.IdentifierName(_newTypesToFields[typeName]);
     }
 
-    public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+    public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         // Capture current mappings so nested classes don't clobber outer state
         var previousMappings = _newTypesToFields;
@@ -72,7 +72,15 @@ public class NewRewriter : CSharpSyntaxRewriter
             List<FieldDeclarationSyntax> fieldDeclarations = new();
 
             // Visit the children nodes to replace all the "new" expressions with identifiers
-            node = (ClassDeclarationSyntax)base.VisitClassDeclaration(node);
+            var visited = base.VisitClassDeclaration(node);
+            if (visited is ClassDeclarationSyntax classNode)
+            {
+                node = classNode;
+            }
+            else
+            {
+                return visited;
+            }
 
             // Create a field for each type that's been new'ed up
             foreach (var entry in _newTypesToFields)

--- a/src/Core/Rewriters/ResolveRewriter.cs
+++ b/src/Core/Rewriters/ResolveRewriter.cs
@@ -23,7 +23,7 @@ public class ResolveRewriter : CSharpSyntaxRewriter
         _logger = logger ?? NullLogger<ResolveRewriter>.Instance;
     }
 
-    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+    public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         if (node.IsStaticMethodOrProperty())
         {
@@ -84,7 +84,7 @@ public class ResolveRewriter : CSharpSyntaxRewriter
         return SyntaxFactory.IdentifierName(_newTypesToFields[actualTypeName]);
     }
 
-    public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+    public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         // Capture current mappings so each class visit starts with a clean slate
         var previousMappings = _newTypesToFields;
@@ -116,7 +116,15 @@ public class ResolveRewriter : CSharpSyntaxRewriter
             }
 
             // Visit the children nodes to replace all the "new" expressions with identifiers
-            node = (ClassDeclarationSyntax)base.VisitClassDeclaration(node);
+            var visited = base.VisitClassDeclaration(node);
+            if (visited is ClassDeclarationSyntax classNode)
+            {
+                node = classNode;
+            }
+            else
+            {
+                return visited;
+            }
 
             // Collect existing field names in the class
             var existingFieldNames = node.Members

--- a/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
@@ -119,7 +119,7 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
         return method.ParameterList.Parameters.Select(p => new ParameterMapping
         {
             Name = p.Identifier.ToString(),
-            Type = p.Type.ToString(),
+            Type = p.Type?.ToString() ?? string.Empty,
             IsNullable = p.Type is NullableTypeSyntax
         }).ToList();
     }

--- a/src/Core/Syntax/NamespaceWalker.cs
+++ b/src/Core/Syntax/NamespaceWalker.cs
@@ -6,9 +6,9 @@ namespace DotnetLegacyMigrator.Syntax;
 /// <summary>
 /// Finds the namespace declaration for a syntax tree.
 /// </summary>
-public class NamespaceWalker : CSharpSyntaxWalker
-{
-    public string Namespace { get; private set; }
+    public class NamespaceWalker : CSharpSyntaxWalker
+    {
+        public string Namespace { get; private set; } = string.Empty;
 
     public override void VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
     {

--- a/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
@@ -50,13 +50,13 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
                     {
                         ReturnType = returnType,
 
-                        MethodName = m.MethodName + returnType,
-                        StoredProcName = m.CommandText,
-                        Parameters = m.Parameters.Select(p => new ParameterMapping()
+                        MethodName = (m.MethodName ?? string.Empty) + returnType,
+                        StoredProcName = m.CommandText ?? string.Empty,
+                        Parameters = m.Parameters?.Select(p => new ParameterMapping()
                         {
                             Name = p.Name,
                             Type = p.SqlDbType,
-                        }).ToList(),
+                        }).ToList() ?? new List<ParameterMapping>(),
 
                     };
 
@@ -190,7 +190,7 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
 
 
 
-    public MethodCommandInfo ExtractCommandInfoFromInitCommandCollection(ClassDeclarationSyntax tableAdapterNode, int parameterIndex)
+    public MethodCommandInfo? ExtractCommandInfoFromInitCommandCollection(ClassDeclarationSyntax tableAdapterNode, int parameterIndex)
     {
         var initCommandCollection = tableAdapterNode.Members
             .OfType<MethodDeclarationSyntax>()
@@ -211,7 +211,7 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
             .FirstOrDefault(ae => ae.Left.ToString().Contains($"_commandCollection[{parameterIndex}].CommandText"));
 
         // Extract CommandText
-        string commandText = null;
+        string? commandText = null;
         if (commandTextExpression?.Right is LiteralExpressionSyntax literalExpression)
         {
             commandText = literalExpression.Token.ValueText;
@@ -220,7 +220,7 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
         return new MethodCommandInfo
         {
             CommandText = commandText,
-            
+
         };
     }
 
@@ -250,17 +250,17 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
 
     public class MethodCommandInfo
     {
-        public string MethodName { get; set; }
+        public string? MethodName { get; set; }
         public int ParameterIndex { get; set; }
-        public string CommandText { get; set; }
-        public List<SqlParameterInfo> Parameters { get; set; }
+        public string? CommandText { get; set; }
+        public List<SqlParameterInfo>? Parameters { get; set; }
     }
 
     public class SqlParameterInfo
     {
-        public string Name { get; set; }
-        public string SqlDbType { get; set; }
+        public required string Name { get; set; }
+        public required string SqlDbType { get; set; }
         public int Size { get; set; }
-        public string Direction { get; set; }
+        public required string Direction { get; set; }
     }
 }

--- a/tests/Translation.Tests/LoggingTests.cs
+++ b/tests/Translation.Tests/LoggingTests.cs
@@ -43,7 +43,7 @@ public class LoggingTests
             _enabled = enabled;
         }
 
-        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
 
         public bool IsEnabled(LogLevel logLevel) => _enabled;
 


### PR DESCRIPTION
## Summary
- add null-safe returns to rewriter overrides
- guard optional Roslyn nodes and initialize properties
- handle nullable command metadata and add test logger constraint

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b7c74ff4832893dfb80b5c61d83e