### PR TITLE
Add schema support for table mappings

### DIFF
--- a/src/Core/CodeGenerator.cs
+++ b/src/Core/CodeGenerator.cs
@@ -142,7 +142,10 @@ public static class CodeGenerator
             sb.AppendLine("{");
             sb.AppendLine($"    public void Configure(EntityTypeBuilder<{entity.Name}> builder)");
             sb.AppendLine("    {");
-            sb.AppendLine($"        builder.ToTable(\"{entity.TableName}\");");
+            var toTable = string.IsNullOrWhiteSpace(entity.Schema)
+                ? $"builder.ToTable(\"{entity.TableName}\");"
+                : $"builder.ToTable(\"{entity.TableName}\", \"{entity.Schema}\");";
+            sb.AppendLine($"        {toTable}");
 
             var keys = entity.Properties.Where(p => p.IsPrimaryKey).ToList();
             if (keys.Count == 1)
@@ -224,7 +227,11 @@ public static class CodeGenerator
         sb.AppendLine("    protected override void OnModelCreating(ModelBuilder modelBuilder)");
         sb.AppendLine("    {");
         foreach (var table in context.Tables.OrderBy(t => t.EntityType))
+        {
             sb.AppendLine($"        modelBuilder.ApplyConfiguration(new {table.EntityType}Configuration());");
+            if (!string.IsNullOrWhiteSpace(table.Schema))
+                sb.AppendLine($"        modelBuilder.Entity<{table.EntityType}>().ToTable(\"{table.Name}\", \"{table.Schema}\");");
+        }
         sb.AppendLine("    }");
 
         // Emit stored procedure wrappers if any were discovered

--- a/src/Core/Models/Entity.cs
+++ b/src/Core/Models/Entity.cs
@@ -8,5 +8,6 @@ public class Entity
     public string Name { get; set; } = string.Empty;
     public List<EntityProperty> Properties { get; set; } = new();
     public string TableName { get; set; } = string.Empty;
+    public string? Schema { get; set; }
     public List<Navigation> Navigations { get; set; } = new();
 }

--- a/src/Core/Models/TableMapping.cs
+++ b/src/Core/Models/TableMapping.cs
@@ -7,5 +7,6 @@ public class TableMapping
 {
     public string Name { get; set; } = string.Empty;
     public string EntityType { get; set; } = string.Empty;
+    public string? Schema { get; set; }
     public List<Navigation> Navigations { get; set; } = new();
 }

--- a/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
@@ -21,6 +21,9 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
             var tableName = tableAttribute.ArgumentList?.Arguments
                 .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Name")?
                 .Expression?.ToString().Trim('"');
+            var schemaName = tableAttribute.ArgumentList?.Arguments
+                .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "Schema")?
+                .Expression?.ToString().Trim('"');
 
             var properties = new List<EntityProperty>();
             var navigations = new List<Navigation>();
@@ -36,6 +39,7 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
             {
                 Name = node.Identifier.ToString(),
                 TableName = tableName ?? node.Identifier.ToString(),
+                Schema = schemaName,
                 Properties = properties,
                 Navigations = navigations
             };

--- a/src/Core/Syntax/NHibernateHbmParser.cs
+++ b/src/Core/Syntax/NHibernateHbmParser.cs
@@ -31,6 +31,7 @@ public static class NHibernateHbmParser
             {
                 var name = classEl.Attribute("name")?.Value ?? "Entity";
                 var table = classEl.Attribute("table")?.Value ?? name;
+                var schema = classEl.Attribute("schema")?.Value;
                 var props = new List<EntityProperty>();
                 var navs = new List<Navigation>();
 
@@ -113,11 +114,12 @@ public static class NHibernateHbmParser
                 {
                     Name = name,
                     TableName = table,
+                    Schema = schema,
                     Properties = props,
                     Navigations = navs
                 });
 
-                tables.Add(new TableMapping { Name = table, EntityType = name, Navigations = navs });
+                tables.Add(new TableMapping { Name = table, EntityType = name, Schema = schema, Navigations = navs });
             }
 
             // Parse simple sql-query elements representing stored procedures

--- a/tests/Translation.Tests/Expected/TypeNormalization/DataContext.txt
+++ b/tests/Translation.Tests/Expected/TypeNormalization/DataContext.txt
@@ -7,5 +7,6 @@ public class DemoContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new DocConfiguration());
+        modelBuilder.Entity<Doc>().ToTable("Docs", "legacy");
     }
 }

--- a/tests/Translation.Tests/Expected/TypeNormalization/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/TypeNormalization/EntityConfigurations.txt
@@ -6,7 +6,7 @@ public class DocConfiguration : IEntityTypeConfiguration<Doc>
 {
     public void Configure(EntityTypeBuilder<Doc> builder)
     {
-        builder.ToTable("Docs");
+        builder.ToTable("Docs", "legacy");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
             .HasColumnName("Id");

--- a/tests/Translation.Tests/TypeNormalizationTests.cs
+++ b/tests/Translation.Tests/TypeNormalizationTests.cs
@@ -13,6 +13,7 @@ public class TypeNormalizationTests
         {
             Name = "Doc",
             TableName = "Docs",
+            Schema = "legacy",
             Properties = new List<EntityProperty>
             {
                 new()
@@ -37,7 +38,7 @@ public class TypeNormalizationTests
             Name = "DemoContext",
             Tables =
             {
-                new TableMapping { Name = "Docs", EntityType = "Doc" }
+                new TableMapping { Name = "Docs", EntityType = "Doc", Schema = "legacy" }
             }
         };
 


### PR DESCRIPTION
## Summary
- add optional `Schema` to table and entity mappings
- parse schema from `[Table]` and NHibernate `<class>` elements
- emit `ToTable(name, schema)` in generated context and configurations
- cover non-default schema in tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a563640e4883288703ae66ece9bbf6