### PR TITLE
Generate relationship configurations

### DIFF
--- a/src/Core/CodeGenerator.cs
+++ b/src/Core/CodeGenerator.cs
@@ -122,8 +122,9 @@ public static class CodeGenerator
     /// <returns>The generated configuration source.</returns>
     public static string GenerateEntityConfigurations(IEnumerable<Entity> entities)
     {
+        var entityList = entities.ToList();
         var extraUsings = new HashSet<string>();
-        foreach (var prop in entities.SelectMany(e => e.Properties))
+        foreach (var prop in entityList.SelectMany(e => e.Properties))
         {
             if (IsXmlType(prop.Type))
                 extraUsings.Add("System.Xml.Linq");
@@ -136,7 +137,9 @@ public static class CodeGenerator
             sb.AppendLine($"using {u};");
         sb.AppendLine();
 
-        foreach (var entity in entities.OrderBy(e => e.Name))
+        var lookup = entityList.ToDictionary(e => e.Name);
+
+        foreach (var entity in entityList.OrderBy(e => e.Name))
         {
             sb.AppendLine($"public class {entity.Name}Configuration : IEntityTypeConfiguration<{entity.Name}>");
             sb.AppendLine("{");
@@ -162,6 +165,37 @@ public static class CodeGenerator
                     calls.Add(".HasConversion(v => v.ToString(), v => XElement.Parse(v))");
                 sb.AppendLine($"        builder.Property(e => e.{prop.Name})");
                 sb.AppendLine($"            {string.Join("\n            ", calls)};");
+            }
+
+            foreach (var nav in entity.Navigations)
+            {
+                if (string.IsNullOrWhiteSpace(nav.ForeignKey) || !string.IsNullOrWhiteSpace(nav.JoinTable))
+                    continue;
+
+                if (nav.IsCollection)
+                {
+                    if (!lookup.TryGetValue(nav.TargetEntity, out var target))
+                        continue;
+                    var fkInTarget = target.Properties.Any(p => p.Name == nav.ForeignKey);
+                    var fkIsPrimaryOfCurrent = entity.Properties.Any(p => p.IsPrimaryKey && p.Name == nav.ForeignKey);
+                    if (!fkInTarget || fkIsPrimaryOfCurrent)
+                        continue;
+                    sb.AppendLine($"        builder.HasMany(e => e.{nav.Name})");
+                    sb.AppendLine(nav.Inverse != null
+                        ? $"            .WithOne(e => e.{nav.Inverse})"
+                        : "            .WithOne()");
+                    sb.AppendLine($"            .HasForeignKey(e => e.{nav.ForeignKey});");
+                }
+                else
+                {
+                    if (!entity.Properties.Any(p => p.Name == nav.ForeignKey))
+                        continue;
+                    sb.AppendLine($"        builder.HasOne(e => e.{nav.Name})");
+                    sb.AppendLine(nav.Inverse != null
+                        ? $"            .WithMany(e => e.{nav.Inverse})"
+                        : "            .WithMany()");
+                    sb.AppendLine($"            .HasForeignKey(e => e.{nav.ForeignKey});");
+                }
             }
 
             sb.AppendLine("    }");

--- a/tests/Translation.Tests/Expected/Relationships/LinqToSql/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/LinqToSql/EntityConfigurations.txt
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.ToTable("Customers");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id");
+    }
+}
+
+public class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        builder.ToTable("Orders");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id");
+        builder.Property(e => e.CustomerId)
+            .HasColumnName("CustomerId");
+        builder.HasOne(e => e.Customer)
+            .WithMany(e => e.Orders)
+            .HasForeignKey(e => e.CustomerId);
+    }
+}

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/EntityConfigurations.txt
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class CourseConfiguration : IEntityTypeConfiguration<Course>
+{
+    public void Configure(EntityTypeBuilder<Course> builder)
+    {
+        builder.ToTable("Courses");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .ValueGeneratedOnAdd();
+    }
+}
+
+public class StudentConfiguration : IEntityTypeConfiguration<Student>
+{
+    public void Configure(EntityTypeBuilder<Student> builder)
+    {
+        builder.ToTable("Students");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .ValueGeneratedOnAdd();
+    }
+}

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/EntityConfigurations.txt
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.ToTable("Customers");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .ValueGeneratedOnAdd();
+        builder.HasMany(e => e.Orders)
+            .WithOne()
+            .HasForeignKey(e => e.CustomerId);
+    }
+}
+
+public class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        builder.ToTable("Orders");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .ValueGeneratedOnAdd();
+        builder.Property(e => e.CustomerId)
+            .HasColumnName("CustomerId");
+        builder.HasOne(e => e.Customer)
+            .WithMany()
+            .HasForeignKey(e => e.CustomerId);
+    }
+}

--- a/tests/Translation.Tests/Expected/Relationships/TypedDataSets/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/TypedDataSets/EntityConfigurations.txt
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
+{
+    public void Configure(EntityTypeBuilder<Customer> builder)
+    {
+        builder.ToTable("Customer");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id");
+        builder.Property(e => e.Name)
+            .HasColumnName("Name")
+            .HasColumnType("NVARCHAR(50)");
+    }
+}
+
+public class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        builder.ToTable("Order");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id");
+        builder.Property(e => e.CustomerId)
+            .HasColumnName("CustomerId");
+        builder.HasOne(e => e.Customer)
+            .WithMany()
+            .HasForeignKey(e => e.CustomerId);
+    }
+}

--- a/tests/Translation.Tests/RelationshipMigrationTests.cs
+++ b/tests/Translation.Tests/RelationshipMigrationTests.cs
@@ -15,9 +15,12 @@ public class RelationshipMigrationTests
         var tree = CSharpSyntaxTree.ParseText(code);
         var walker = new LinqToSqlEntitySyntaxWalker();
         walker.Visit(tree.GetRoot());
-        var output = CodeGenerator.GenerateEntities(walker.Entities);
-        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "LinqToSql", "Entities.txt"));
-        Assert.Equal(Normalize(expected), Normalize(output));
+        var entityText = CodeGenerator.GenerateEntities(walker.Entities);
+        var configText = CodeGenerator.GenerateEntityConfigurations(walker.Entities);
+        var expectedEntities = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "LinqToSql", "Entities.txt"));
+        var expectedConfig = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "LinqToSql", "EntityConfigurations.txt"));
+        Assert.Equal(Normalize(expectedEntities), Normalize(entityText));
+        Assert.Equal(Normalize(expectedConfig), Normalize(configText));
     }
 
     [Fact]
@@ -30,9 +33,12 @@ public class RelationshipMigrationTests
         File.WriteAllText(f1, studentHbm);
         File.WriteAllText(f2, courseHbm);
         var (_, entities) = NHibernateHbmParser.ParseFiles(new[] { f1, f2 });
-        var output = CodeGenerator.GenerateEntities(entities);
-        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "Entities.txt"));
-        Assert.Equal(Normalize(expected), Normalize(output));
+        var entityText = CodeGenerator.GenerateEntities(entities);
+        var configText = CodeGenerator.GenerateEntityConfigurations(entities);
+        var expectedEntities = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "Entities.txt"));
+        var expectedConfig = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "EntityConfigurations.txt"));
+        Assert.Equal(Normalize(expectedEntities), Normalize(entityText));
+        Assert.Equal(Normalize(expectedConfig), Normalize(configText));
     }
 
     [Fact]
@@ -45,9 +51,12 @@ public class RelationshipMigrationTests
         File.WriteAllText(f1, customerHbm);
         File.WriteAllText(f2, orderHbm);
         var (_, entities) = NHibernateHbmParser.ParseFiles(new[] { f1, f2 });
-        var output = CodeGenerator.GenerateEntities(entities);
-        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "Entities.txt"));
-        Assert.Equal(Normalize(expected), Normalize(output));
+        var entityText = CodeGenerator.GenerateEntities(entities);
+        var configText = CodeGenerator.GenerateEntityConfigurations(entities);
+        var expectedEntities = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "Entities.txt"));
+        var expectedConfig = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "NHibernate", "OneToMany", "EntityConfigurations.txt"));
+        Assert.Equal(Normalize(expectedEntities), Normalize(entityText));
+        Assert.Equal(Normalize(expectedConfig), Normalize(configText));
     }
 
     [Fact]
@@ -64,9 +73,12 @@ public class RelationshipMigrationTests
         var tree = CSharpSyntaxTree.ParseText(designer, path: designerPath);
         var walker = new TypedDatasetEntitySyntaxWalker();
         walker.Visit(tree.GetRoot());
-        var output = CodeGenerator.GenerateEntities(walker.Entities);
-        var expected = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "Entities.txt"));
-        Assert.Equal(Normalize(expected), Normalize(output));
+        var entityText = CodeGenerator.GenerateEntities(walker.Entities);
+        var configText = CodeGenerator.GenerateEntityConfigurations(walker.Entities);
+        var expectedEntities = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "Entities.txt"));
+        var expectedConfig = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "Relationships", "TypedDataSets", "EntityConfigurations.txt"));
+        Assert.Equal(Normalize(expectedEntities), Normalize(entityText));
+        Assert.Equal(Normalize(expectedConfig), Normalize(configText));
     }
 
     private static string ExpectedPath(params string[] parts)


### PR DESCRIPTION
## Summary
- generate `HasOne`/`HasMany` relationship mappings for navigations with foreign keys
- verify generated configuration for LinqToSql, NHibernate and typed datasets

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a56351864c8328ade9a757c8bed847