### PR TITLE
Handle requiredness for generated properties

### DIFF
--- a/src/Core/CodeGenerator.cs
+++ b/src/Core/CodeGenerator.cs
@@ -160,6 +160,8 @@ public static class CodeGenerator
                     calls.Add(".ValueGeneratedOnAdd()");
                 if (IsXmlType(prop.Type))
                     calls.Add(".HasConversion(v => v.ToString(), v => XElement.Parse(v))");
+                // Mark whether the property is required based on nullability
+                calls.Add(prop.IsNullable ? ".IsRequired(false)" : ".IsRequired()");
                 sb.AppendLine($"        builder.Property(e => e.{prop.Name})");
                 sb.AppendLine($"            {string.Join("\n            ", calls)};");
             }

--- a/tests/Translation.Tests/Expected/TypeNormalization/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/TypeNormalization/EntityConfigurations.txt
@@ -9,10 +9,12 @@ public class DocConfiguration : IEntityTypeConfiguration<Doc>
         builder.ToTable("Docs");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
-            .HasColumnName("Id");
+            .HasColumnName("Id")
+            .IsRequired();
         builder.Property(e => e.Content)
             .HasColumnName("Content")
             .HasColumnType("XML")
-            .HasConversion(v => v.ToString(), v => XElement.Parse(v));
+            .HasConversion(v => v.ToString(), v => XElement.Parse(v))
+            .IsRequired(false);
     }
 }

--- a/tests/Translation.Tests/TypeNormalizationTests.cs
+++ b/tests/Translation.Tests/TypeNormalizationTests.cs
@@ -20,7 +20,8 @@ public class TypeNormalizationTests
                     Name = "Id",
                     Type = "System.Int32",
                     IsPrimaryKey = true,
-                    ColumnName = "Id"
+                    ColumnName = "Id",
+                    IsNullable = false
                 },
                 new()
                 {
@@ -28,6 +29,7 @@ public class TypeNormalizationTests
                     Type = "System.Xml.Linq.XElement?",
                     ColumnName = "Content",
                     DbType = "XML",
+                    IsNullable = true
                 }
             }
         };


### PR DESCRIPTION
## Summary
- mark generated property configurations as required or optional based on metadata
- cover nullable vs non-nullable properties in TypeNormalization tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a5634a0f5083288d51ea11fb18d980