### PR TITLE
Update expected configuration templates for required properties

### DIFF
--- a/tests/Translation.Tests/Expected/Relationships/LinqToSql/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/LinqToSql/EntityConfigurations.txt
@@ -8,7 +8,8 @@ public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         builder.ToTable("Customers");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
-            .HasColumnName("Id");
+            .HasColumnName("Id")
+            .IsRequired();
     }
 }
 
@@ -19,9 +20,11 @@ public class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.ToTable("Orders");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
-            .HasColumnName("Id");
+            .HasColumnName("Id")
+            .IsRequired();
         builder.Property(e => e.CustomerId)
-            .HasColumnName("CustomerId");
+            .HasColumnName("CustomerId")
+            .IsRequired();
         builder.HasOne(e => e.Customer)
             .WithMany(e => e.Orders)
             .HasForeignKey(e => e.CustomerId);

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/EntityConfigurations.txt
@@ -9,7 +9,8 @@ public class CourseConfiguration : IEntityTypeConfiguration<Course>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
             .HasColumnName("Id")
-            .ValueGeneratedOnAdd();
+            .ValueGeneratedOnAdd()
+            .IsRequired();
     }
 }
 
@@ -21,6 +22,7 @@ public class StudentConfiguration : IEntityTypeConfiguration<Student>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
             .HasColumnName("Id")
-            .ValueGeneratedOnAdd();
+            .ValueGeneratedOnAdd()
+            .IsRequired();
     }
 }

--- a/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/NHibernate/OneToMany/EntityConfigurations.txt
@@ -9,7 +9,8 @@ public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
             .HasColumnName("Id")
-            .ValueGeneratedOnAdd();
+            .ValueGeneratedOnAdd()
+            .IsRequired();
         builder.HasMany(e => e.Orders)
             .WithOne()
             .HasForeignKey(e => e.CustomerId);
@@ -24,9 +25,11 @@ public class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
             .HasColumnName("Id")
-            .ValueGeneratedOnAdd();
+            .ValueGeneratedOnAdd()
+            .IsRequired();
         builder.Property(e => e.CustomerId)
-            .HasColumnName("CustomerId");
+            .HasColumnName("CustomerId")
+            .IsRequired();
         builder.HasOne(e => e.Customer)
             .WithMany()
             .HasForeignKey(e => e.CustomerId);

--- a/tests/Translation.Tests/Expected/Relationships/TypedDataSets/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/Relationships/TypedDataSets/EntityConfigurations.txt
@@ -8,10 +8,12 @@ public class CustomerConfiguration : IEntityTypeConfiguration<Customer>
         builder.ToTable("Customer");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
-            .HasColumnName("Id");
+            .HasColumnName("Id")
+            .IsRequired();
         builder.Property(e => e.Name)
             .HasColumnName("Name")
-            .HasColumnType("NVARCHAR(50)");
+            .HasColumnType("NVARCHAR(50)")
+            .IsRequired();
     }
 }
 
@@ -22,9 +24,11 @@ public class OrderConfiguration : IEntityTypeConfiguration<Order>
         builder.ToTable("Order");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id)
-            .HasColumnName("Id");
+            .HasColumnName("Id")
+            .IsRequired();
         builder.Property(e => e.CustomerId)
-            .HasColumnName("CustomerId");
+            .HasColumnName("CustomerId")
+            .IsRequired();
         builder.HasOne(e => e.Customer)
             .WithMany()
             .HasForeignKey(e => e.CustomerId);


### PR DESCRIPTION
## Summary
- include `IsRequired()` calls in LINQ to SQL relationship configuration template
- add missing `IsRequired()` in NHibernate relationship configuration templates
- update typed DataSet configuration templates to mark required fields

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a56b7983308328a234e3b26c9fdac4