### PR TITLE
fix: remove RS1034 warnings in syntax walkers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - All non-example projects, tests, and CI must target **.NET 9.0**.
 - Keep the repository's `global.json`, project files, and GitHub Actions in sync with the .NET 9 SDK.
+- Always try to resolve build warnings before completing a task.
 - Example projects may target different frameworks only when the legacy technology being demonstrated requires it.
 - When asserting generated output in tests, store the expected code under `tests/Translation.Tests/Expected` (or a relevant subfolder) rather than embedding it inline within the test source.
 - Ensure the .NET SDK version specified in `global.json` (currently `9.0.303`) is installed before running `dotnet` commands. If absent, install it using the official script:

--- a/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Text.RegularExpressions;
@@ -120,9 +121,9 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
         return method.ParameterList.Parameters.Select(p =>
         {
             var direction = "Input";
-            if (p.Modifiers.Any(m => m.Kind() == SyntaxKind.OutKeyword))
+            if (p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword)))
                 direction = "Output";
-            else if (p.Modifiers.Any(m => m.Kind() == SyntaxKind.RefKeyword))
+            else if (p.Modifiers.Any(m => m.IsKind(SyntaxKind.RefKeyword)))
                 direction = "InputOutput";
 
             int? size = null;

--- a/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
@@ -158,8 +158,8 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
                 {
                     Name = p.Identifier.ToString(),
                     SqlDbType = p.Type?.ToString() ?? "Unknown",
-                    Direction = p.Modifiers.Any(m => m.Kind() == SyntaxKind.OutKeyword) ? "Output" :
-                                p.Modifiers.Any(m => m.Kind() == SyntaxKind.RefKeyword) ? "InputOutput" : "Input"
+                    Direction = p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword)) ? "Output" :
+                                p.Modifiers.Any(m => m.IsKind(SyntaxKind.RefKeyword)) ? "InputOutput" : "Input"
                 }).ToList();
 
             var methodName = method.Identifier.ToString();


### PR DESCRIPTION
## Summary
- note to resolve build warnings in AGENTS guide
- replace `Kind()` comparisons with `IsKind` in syntax walkers to satisfy analyzer RS1034

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a56fb792ec8328b06131e0b0d50449