### PR TITLE
Handle composite primary keys and identity columns in typed datasets

### DIFF
--- a/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetEntitySyntaxWalker.cs
@@ -120,15 +120,15 @@ public class TypedDatasetEntitySyntaxWalker : CSharpSyntaxWalker
     private IEnumerable<EntityProperty> ExtractEntityProperties(DataTable dt)
     {
         // Parse the DataColumn initializations in InitClass
+        var primaryKeys = new HashSet<string>(dt.PrimaryKey.Select(pk => pk.ColumnName));
         foreach (DataColumn c in dt.Columns)
         {
-
             yield return new EntityProperty
             {
                 Name = c.ColumnName,
                 Type = GetColumnType(c),
-                IsPrimaryKey = dt.PrimaryKey.Any(cc => cc == c) || dt.Columns.Count == 1, // This information is typically unavailable in the code
-                IsDbGenerated = false, // Same as above
+                IsPrimaryKey = primaryKeys.Contains(c.ColumnName) || dt.Columns.Count == 1, // Fallback if no PK info
+                IsDbGenerated = c.AutoIncrement,
                 ColumnName = c.ColumnName,
                 DbType = c.DataType == typeof(string) && c.MaxLength > 0 ? $"NVARCHAR({c.MaxLength})" : null,
                 IsNullable = c.AllowDBNull

--- a/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/Entities.txt
+++ b/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/Entities.txt
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+public class CompositeTable
+{
+    public int KeyPart1 { get; set; }
+
+    public int KeyPart2 { get; set; }
+
+    public string? Name { get; set; }
+
+}
+
+public class IdentityTable
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; }
+
+}

--- a/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/EntityConfigurations.txt
+++ b/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/EntityConfigurations.txt
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public class CompositeTableConfiguration : IEntityTypeConfiguration<CompositeTable>
+{
+    public void Configure(EntityTypeBuilder<CompositeTable> builder)
+    {
+        builder.ToTable("CompositeTable");
+        builder.HasKey(e => new { e.KeyPart1, e.KeyPart2 });
+        builder.Property(e => e.KeyPart1)
+            .HasColumnName("KeyPart1")
+            .IsRequired();
+        builder.Property(e => e.KeyPart2)
+            .HasColumnName("KeyPart2")
+            .IsRequired();
+        builder.Property(e => e.Name)
+            .HasColumnName("Name")
+            .HasColumnType("NVARCHAR(50)")
+            .IsRequired(false);
+    }
+}
+
+public class IdentityTableConfiguration : IEntityTypeConfiguration<IdentityTable>
+{
+    public void Configure(EntityTypeBuilder<IdentityTable> builder)
+    {
+        builder.ToTable("IdentityTable");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .ValueGeneratedOnAdd()
+            .IsRequired();
+        builder.Property(e => e.Name)
+            .HasColumnName("Name")
+            .HasColumnType("NVARCHAR(50)")
+            .IsRequired();
+    }
+}

--- a/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/KeyDataSet.Designer.cs
+++ b/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/KeyDataSet.Designer.cs
@@ -1,0 +1,17 @@
+using System.Data;
+
+public class CompositeTableDataTable : DataTable
+{
+    public CompositeTableDataTable()
+    {
+        this.TableName = "CompositeTable";
+    }
+}
+
+public class IdentityTableDataTable : DataTable
+{
+    public IdentityTableDataTable()
+    {
+        this.TableName = "IdentityTable";
+    }
+}

--- a/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/KeyDataSet.xsd
+++ b/tests/Translation.Tests/Expected/TypedDataSets/KeyScenarios/KeyDataSet.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema id="KeyDataSet" xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xs:element name="KeyDataSet" msdata:IsDataSet="true">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="CompositeTable">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="KeyPart1" type="xs:int" />
+              <xs:element name="KeyPart2" type="xs:int" />
+              <xs:element name="Name" minOccurs="0">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:maxLength value="50" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="IdentityTable">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Id" type="xs:int" msdata:AutoIncrement="true" msdata:AutoIncrementSeed="1" msdata:AutoIncrementStep="1" />
+              <xs:element name="Name">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:maxLength value="50" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+    <xs:unique name="CompositeTableKey" msdata:PrimaryKey="true">
+      <xs:selector xpath=".//CompositeTable" />
+      <xs:field xpath="KeyPart1" />
+      <xs:field xpath="KeyPart2" />
+    </xs:unique>
+    <xs:unique name="IdentityTableKey" msdata:PrimaryKey="true">
+      <xs:selector xpath=".//IdentityTable" />
+      <xs:field xpath="Id" />
+    </xs:unique>
+  </xs:element>
+</xs:schema>

--- a/tests/Translation.Tests/TypedDatasetKeyTests.cs
+++ b/tests/Translation.Tests/TypedDatasetKeyTests.cs
@@ -1,0 +1,45 @@
+using DotnetLegacyMigrator;
+using DotnetLegacyMigrator.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Translation.Tests;
+
+public class TypedDatasetKeyTests
+{
+    [Fact]
+    public void TypedDataSet_CompositeKeys_And_IdentityColumns_AreHandled()
+    {
+        var designer = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "KeyScenarios", "KeyDataSet.Designer.cs"));
+        var xsd = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "KeyScenarios", "KeyDataSet.xsd"));
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var designerPath = Path.Combine(dir, "KeyDataSet.Designer.cs");
+        var xsdPath = Path.Combine(dir, "KeyDataSet.xsd");
+        File.WriteAllText(designerPath, designer);
+        File.WriteAllText(xsdPath, xsd);
+        var tree = CSharpSyntaxTree.ParseText(designer, path: designerPath);
+        var walker = new TypedDatasetEntitySyntaxWalker();
+        walker.Visit(tree.GetRoot());
+        var entityText = CodeGenerator.GenerateEntities(walker.Entities);
+        var configText = CodeGenerator.GenerateEntityConfigurations(walker.Entities);
+        var expectedEntities = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "KeyScenarios", "Entities.txt"));
+        var expectedConfig = File.ReadAllText(ExpectedPath("tests", "Translation.Tests", "Expected", "TypedDataSets", "KeyScenarios", "EntityConfigurations.txt"));
+        Assert.Equal(Normalize(expectedEntities), Normalize(entityText));
+        Assert.Equal(Normalize(expectedConfig), Normalize(configText));
+        var composite = walker.Entities.Single(e => e.Name == "CompositeTable");
+        Assert.Equal(new[] { "KeyPart1", "KeyPart2" }, composite.Properties.Where(p => p.IsPrimaryKey).Select(p => p.Name).ToArray());
+        var identity = walker.Entities.Single(e => e.Name == "IdentityTable");
+        Assert.True(identity.Properties.Single(p => p.Name == "Id").IsDbGenerated);
+    }
+
+    private static string ExpectedPath(params string[] parts)
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        return Path.Combine(new[] { root }.Concat(parts).ToArray());
+    }
+
+    private static string Normalize(string input) => input.Replace("\r\n", "\n").Trim();
+}


### PR DESCRIPTION
## Summary
- capture all primary key columns from DataTable.PrimaryKey and mark auto-increment columns as database-generated
- add tests covering composite keys and identity columns for typed datasets

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a573095e348328b8db74716da8a227