### PR TITLE
Use syntax identifiers for attribute matching

### DIFF
--- a/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlContextSyntaxWalker.cs
@@ -14,7 +14,7 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
     public override void VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         if (node.BaseList != null && node.BaseList.Types
-                .Any(t => t.Type.ToString().Contains("DataContext")))
+                .Any(t => SyntaxUtils.HasIdentifier(t.Type, "DataContext")))
         {
             var context = new DataContext
             {
@@ -53,7 +53,7 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
     {
         var attribute = m.AttributeLists
             .SelectMany(a => a.Attributes)
-            .First(a => a.Name.ToString().Contains("Function"));
+            .First(a => SyntaxUtils.HasIdentifier(a, "Function"));
 
         var nameArgument = attribute.ArgumentList?.Arguments
             .First(arg => arg.NameEquals?.Name.Identifier.Text == "Name");
@@ -108,7 +108,7 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
     {
         return method.AttributeLists
             .SelectMany(a => a.Attributes)
-            .Any(a => a.Name.ToString().Contains("Function"));
+            .Any(a => SyntaxUtils.HasIdentifier(a, "Function"));
     }
 
     private string GetReturnType(MethodDeclarationSyntax method)
@@ -128,7 +128,7 @@ public class LinqToSqlContextSyntaxWalker : CSharpSyntaxWalker
 
             int? size = null;
             var attr = p.AttributeLists.SelectMany(a => a.Attributes)
-                .FirstOrDefault(a => a.Name.ToString().Contains("Parameter"));
+                .FirstOrDefault(a => SyntaxUtils.HasIdentifier(a, "Parameter"));
             var dbTypeArg = attr?.ArgumentList?.Arguments
                 .FirstOrDefault(arg => arg.NameEquals?.Name.Identifier.Text == "DbType");
             var dbType = dbTypeArg?.Expression.ToString().Trim('"');

--- a/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
+++ b/src/Core/Syntax/LinqToSqlEntitySyntaxWalker.cs
@@ -14,7 +14,7 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
     {
         var tableAttribute = node.AttributeLists
             .SelectMany(al => al.Attributes)
-            .FirstOrDefault(a => a.Name.ToString().Contains("Table"));
+            .FirstOrDefault(a => SyntaxUtils.HasIdentifier(a, "Table"));
 
         var baseTypeName = node.BaseList?.Types.FirstOrDefault()?.Type.ToString();
         if (tableAttribute != null)
@@ -168,7 +168,7 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
         // Heuristic: if the class name ends with "Result" and has no TableAttribute, we consider it a stored procedure result type
         return node.Identifier.ToString().EndsWith("Result") && !node.AttributeLists
             .SelectMany(al => al.Attributes)
-            .Any(a => a.Name.ToString().Contains("TableAttribute"));
+            .Any(a => SyntaxUtils.HasIdentifier(a, "Table"));
     }
 
     private bool TryGetNavigation(PropertyDeclarationSyntax p, out Navigation nav)
@@ -176,7 +176,7 @@ public class LinqToSqlEntitySyntaxWalker : CSharpSyntaxWalker
         nav = default!;
         var assoc = p.AttributeLists
             .SelectMany(al => al.Attributes)
-            .FirstOrDefault(a => a.Name.ToString().Contains("Association"));
+            .FirstOrDefault(a => SyntaxUtils.HasIdentifier(a, "Association"));
         if (assoc == null)
             return false;
 

--- a/src/Core/Syntax/SyntaxUtils.cs
+++ b/src/Core/Syntax/SyntaxUtils.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DotnetLegacyMigrator.Syntax;
+
+internal static class SyntaxUtils
+{
+    public static string GetIdentifier(NameSyntax name) => name switch
+    {
+        IdentifierNameSyntax identifier => identifier.Identifier.Text,
+        QualifiedNameSyntax qualified => GetIdentifier(qualified.Right),
+        AliasQualifiedNameSyntax alias => alias.Name.Identifier.Text,
+        _ => string.Empty
+    };
+
+    public static bool HasIdentifier(AttributeSyntax attribute, string expected)
+    {
+        var id = GetIdentifier(attribute.Name);
+        return id == expected || id == $"{expected}Attribute";
+    }
+
+    public static bool HasIdentifier(TypeSyntax type, string expected) => type switch
+    {
+        IdentifierNameSyntax identifier => identifier.Identifier.Text == expected,
+        QualifiedNameSyntax qualified => GetIdentifier(qualified) == expected,
+        GenericNameSyntax generic => generic.Identifier.Text == expected,
+        _ => false
+    };
+}


### PR DESCRIPTION
## Summary
- add SyntaxUtils to resolve identifier names for attributes and types
- switch LinqToSqlContextSyntaxWalker to identifier-based comparisons for data contexts, functions, and parameters
- switch LinqToSqlEntitySyntaxWalker to identifier-based comparisons for tables and associations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a577dcb36c8328a054efacde27db41