### PR TITLE
Refactor TableAdapter method query with LINQ

### DIFF
--- a/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
+++ b/src/Core/Syntax/TypedDatasetSyntaxWalker.cs
@@ -113,22 +113,11 @@ public class TypedDatasetSyntaxWalker : CSharpSyntaxWalker
 
     public List<MethodDeclarationSyntax> GetTableAdapterMethodsWithDataObjectMethod(ClassDeclarationSyntax tableAdapterNode)
     {
-        // Initialize a list to store matching methods
-        var methodsWithDataObjectMethod = new List<MethodDeclarationSyntax>();
-
-        // Iterate through all method declarations in the TableAdapter node
-        foreach (var method in tableAdapterNode.Members.OfType<MethodDeclarationSyntax>())
-        {
-            // Check if the method has the desired attribute
-            if (method.AttributeLists
-                .SelectMany(attrList => attrList.Attributes)
+        return tableAdapterNode.Members
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.AttributeLists.SelectMany(a => a.Attributes)
                 .Any(attr => attr.ToString().Contains("System.ComponentModel.DataObjectMethod")))
-            {
-                methodsWithDataObjectMethod.Add(method);
-            }
-        }
-
-        return methodsWithDataObjectMethod;
+            .ToList();
     }
 
     public List<MethodCommandInfo> ExtractMethodCommandInfo(ClassDeclarationSyntax tableAdapterNode)


### PR DESCRIPTION
## Summary
- simplify `GetTableAdapterMethodsWithDataObjectMethod` by using a LINQ pipeline to collect methods marked with `DataObjectMethod`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a57b20bbfc83289285c6c2975b20d3