### PR TITLE
chore: enable analyzers and standardize editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,29 @@
 root = true
 
-# Use UTF-8 encoding without BOM
-[*]
+[*.cs]
 charset = utf-8
+indent_style = space
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_require_accessibility_modifiers = always:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_new_line_before_open_brace = all
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_prefer_braces = when_multiline:suggestion
+dotnet_diagnostic.IDE0066.severity = warning   # convert switch to switch expression
+dotnet_diagnostic.IDE0072.severity = warning   # switch cases can be simplified
+dotnet_diagnostic.IDE0010.severity = warning   # add/modify required cases
+dotnet_diagnostic.IDE0044.severity = suggestion # make field readonly
+dotnet_analyzer_diagnostic.severity = warning
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,17 @@
   ```bash
   curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
   bash dotnet-install.sh -v 9.0.303
-  export PATH="$HOME/.dotnet:$PATH"
-  ```
+    export PATH="$HOME/.dotnet:$PATH"
+    ```
+
+You are a senior C# engineer. Refactor the code that follows using these rules:
+
+- Prefer pattern matching (`is`, property/relational patterns) and switch expressions for multi-branch logic; avoid type tests + casts.
+- Add guard clauses; reduce nesting; extract methods for complex logic.
+- Enable nullability; avoid returning null collections; use `ThrowIfNull`/`ThrowIfNegative`.
+- Prefer records for DTOs; make fields `readonly`; use `init` setters.
+- Use target-typed `new()` and expression-bodied members when they improve readability.
+- Keep public async APIs truly async; propagate `CancellationToken`.
+- Replace magic numbers/strings with named constants or enums.
+- Maintain behavior and public contracts; keep changes safe and incremental.
+- Follow .editorconfig settings (assume file-scoped namespaces, 4-space indent).

--- a/examples/LinqToSql/LinqToSqlDemo/LinqToSqlDemo.csproj
+++ b/examples/LinqToSql/LinqToSqlDemo/LinqToSqlDemo.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/examples/NHibernate/NHibernateDemo/NHibernateDemo.csproj
+++ b/examples/NHibernate/NHibernateDemo/NHibernateDemo.csproj
@@ -21,4 +21,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/examples/TypedDataSets/TypedDataSetDemo/TypedDataSetDemo.csproj
+++ b/examples/TypedDataSets/TypedDataSetDemo/TypedDataSetDemo.csproj
@@ -14,4 +14,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/Cli/DotnetLegacyMigrator.Cli.csproj
+++ b/src/Cli/DotnetLegacyMigrator.Cli.csproj
@@ -12,4 +12,9 @@
     <ProjectReference Include="../Core/DotnetLegacyMigrator.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/Core/DotnetLegacyMigrator.Core.csproj
+++ b/src/Core/DotnetLegacyMigrator.Core.csproj
@@ -18,4 +18,9 @@
       <PackageReference Include="Spectre.Console" Version="0.49.1" />
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+    </ItemGroup>
+
 </Project>

--- a/tests/Translation.Tests/Translation.Tests.csproj
+++ b/tests/Translation.Tests/Translation.Tests.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="*" PrivateAssets="all" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- define consistent C# style guidelines via root .editorconfig
- enable Microsoft.CodeAnalysis.NetAnalyzers and StyleCop.Analyzers in all projects
- document refactoring expectations in AGENTS.md

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a57dbbb8ec8328a8fd25156b16521d