### PR TITLE
Format models to reduce StyleCop warnings

### DIFF
--- a/src/Core/Models/DataContext.cs
+++ b/src/Core/Models/DataContext.cs
@@ -6,6 +6,8 @@ namespace DotnetLegacyMigrator.Models;
 public class DataContext
 {
     public string Name { get; set; } = string.Empty;
-    public List<TableMapping> Tables { get; set; } = new();
-    public List<StoredProcedureMapping> StoredProcedures { get; set; } = new();
+
+    public List<TableMapping> Tables { get; set; } = new List<TableMapping>();
+
+    public List<StoredProcedureMapping> StoredProcedures { get; set; } = new List<StoredProcedureMapping>();
 }

--- a/src/Core/Models/Entity.cs
+++ b/src/Core/Models/Entity.cs
@@ -6,12 +6,17 @@ namespace DotnetLegacyMigrator.Models;
 public class Entity
 {
     public string Name { get; set; } = string.Empty;
+
     /// <summary>
     /// If set, indicates the name of the base entity type this entity inherits from.
     /// </summary>
     public string? BaseType { get; set; }
-    public List<EntityProperty> Properties { get; set; } = new();
+
+    public List<EntityProperty> Properties { get; set; } = new List<EntityProperty>();
+
     public string TableName { get; set; } = string.Empty;
+
     public string? Schema { get; set; }
-    public List<Navigation> Navigations { get; set; } = new();
+
+    public List<Navigation> Navigations { get; set; } = new List<Navigation>();
 }

--- a/src/Core/Models/EntityProperty.cs
+++ b/src/Core/Models/EntityProperty.cs
@@ -6,10 +6,16 @@ namespace DotnetLegacyMigrator.Models;
 public class EntityProperty
 {
     public string Name { get; set; } = string.Empty;
+
     public string Type { get; set; } = string.Empty;
+
     public string? ColumnName { get; set; }
+
     public string? DbType { get; set; }
+
     public bool IsPrimaryKey { get; set; }
+
     public bool IsDbGenerated { get; set; }
+
     public bool IsNullable { get; set; }
 }

--- a/src/Core/Models/Navigation.cs
+++ b/src/Core/Models/Navigation.cs
@@ -6,10 +6,16 @@ namespace DotnetLegacyMigrator.Models;
 public class Navigation
 {
     public string Name { get; set; } = string.Empty;
+
     public string TargetEntity { get; set; } = string.Empty;
+
     public bool IsCollection { get; set; }
+
     public string? ForeignKey { get; set; }
+
     public string? AssociationName { get; set; }
+
     public string? JoinTable { get; set; }
+
     public string? Inverse { get; set; }
 }

--- a/src/Core/Models/ParameterMapping.cs
+++ b/src/Core/Models/ParameterMapping.cs
@@ -6,7 +6,9 @@ namespace DotnetLegacyMigrator.Models;
 public class ParameterMapping
 {
     public string Name { get; set; } = string.Empty;
+
     public string Type { get; set; } = string.Empty;
+
     public bool IsNullable { get; set; }
 
     /// <summary>

--- a/src/Core/Models/StoredProcedureMapping.cs
+++ b/src/Core/Models/StoredProcedureMapping.cs
@@ -6,7 +6,10 @@ namespace DotnetLegacyMigrator.Models;
 public class StoredProcedureMapping
 {
     public string MethodName { get; set; } = string.Empty;
+
     public string ReturnType { get; set; } = string.Empty;
-    public List<ParameterMapping> Parameters { get; set; } = new();
+
+    public List<ParameterMapping> Parameters { get; set; } = new List<ParameterMapping>();
+
     public string StoredProcName { get; set; } = string.Empty;
 }

--- a/src/Core/Models/StoredProcedureResult.cs
+++ b/src/Core/Models/StoredProcedureResult.cs
@@ -6,5 +6,6 @@ namespace DotnetLegacyMigrator.Models;
 public class StoredProcedureResult
 {
     public string Name { get; set; } = string.Empty;
-    public List<EntityProperty> Properties { get; set; } = new();
+
+    public List<EntityProperty> Properties { get; set; } = new List<EntityProperty>();
 }

--- a/src/Core/Models/TableMapping.cs
+++ b/src/Core/Models/TableMapping.cs
@@ -6,7 +6,10 @@ namespace DotnetLegacyMigrator.Models;
 public class TableMapping
 {
     public string Name { get; set; } = string.Empty;
+
     public string EntityType { get; set; } = string.Empty;
+
     public string? Schema { get; set; }
-    public List<Navigation> Navigations { get; set; } = new();
+
+    public List<Navigation> Navigations { get; set; } = new List<Navigation>();
 }


### PR DESCRIPTION
## Summary
- add explicit types for target-typed `new` in models
- insert blank lines to satisfy StyleCop element spacing rules

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a598fe07cc83288c5a92d0874c0b37